### PR TITLE
config: set default bind address and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Basically none
 
 ### Usage
 
-Set `BIND` environment variable to configure bind address
+Set `BIND` environment variable to configure bind address.
+
+ - defaults to `127.0.0.1`
 
 Set `PORT` environment variable to configure bind port
+
+ - defaults to `8000`
 
 Arguments are a comma-separated list of `<url-path>:<file-path>` pairs.
 
@@ -24,7 +28,8 @@ BIND=0.0.0.0 PORT=8081 just-files /:/www
 
 ### Building
 
-The `just-files` file server is written in Go. IT can be built using the normal Go toolchain steps, e.g.
+The `just-files` file server is written in Go. IT can be built using the normal
+Go toolchain steps, e.g.
 
 ```shell
 go build

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -23,6 +22,13 @@ func main() {
 	}
 }
 
+func envOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
 func run(args []string) error {
 	m, err := paths(args[1:])
 	if err != nil {
@@ -31,11 +37,9 @@ func run(args []string) error {
 
 	lockdown(m)
 
-	bind := os.Getenv("BIND")
-	port := os.Getenv("PORT")
-	if bind == "" || port == "" {
-		return errors.New("$BIND and $PORT must be set")
-	}
+	bind := envOr("BIND", "127.0.0.1")
+	port := envOr("PORT", "8000")
+
 	log.Println("bind is", bind)
 	log.Println("port is", port)
 

--- a/main_test.go
+++ b/main_test.go
@@ -13,8 +13,10 @@ import (
 func TestRun(t *testing.T) {
 	t.Setenv("BIND", "127.0.0.1")
 	t.Setenv("PORT", "8787")
+
 	dir, err := os.MkdirTemp("", "")
 	must.NoError(t, err)
+
 	filename := filepath.Join(dir, "hi.txt")
 	err = os.WriteFile(filename, []byte("hello"), 0o644)
 	must.NoError(t, err)


### PR DESCRIPTION
If `BIND` and/or `PORT` are not set, they now default to `127.0.0.1` and `8000`
respectively.

Closes #21
